### PR TITLE
VFM inference and PCAs passthrough the vfm typs

### DIFF
--- a/config/ros/yamaha_voxel_mapping.yaml
+++ b/config/ros/yamaha_voxel_mapping.yaml
@@ -57,7 +57,6 @@ image_processing:
     # - 
     #     type: pca
     #     args:
-    #         # fp: physics_atv_visual_mapping/pca/new_radiob.pt
     #         fp: physics_atv_visual_mapping/pca/radio_v3b_siglip2.pt
 
 # voxel

--- a/physics_atv_visual_mapping/image_processing/processing_blocks/dino.py
+++ b/physics_atv_visual_mapping/image_processing/processing_blocks/dino.py
@@ -18,6 +18,7 @@ class Dinov2Block(ImageProcessingBlock):
         self, dino_type, dino_layers, image_insize, desc_facet, device, models_dir
     ):
         torch.hub.set_dir(os.path.join(models_dir, "torch_hub"))
+        self.dino_type = dino_type
 
         if "dino" in dino_type:
             dino_dir = os.path.join(models_dir, "torch_hub", "facebookresearch_dinov2_main")
@@ -55,6 +56,6 @@ class Dinov2Block(ImageProcessingBlock):
         n_layers = sum(self.dino.dino_model.embed_dim for layer in self.dino.layers)
 
         return FeatureKeyList(
-            label=[f"dino_{i}" for i in range(n_layers)],
+            label=[f"{self.dino_type}_{i}" for i in range(n_layers)],
             metainfo=["vfm" for i in range(n_layers)]
         )

--- a/physics_atv_visual_mapping/image_processing/processing_blocks/radio_lang.py
+++ b/physics_atv_visual_mapping/image_processing/processing_blocks/radio_lang.py
@@ -216,8 +216,7 @@ class RadioLangBlock(ImageProcessingBlock):
     @property
     def output_feature_keys(self):
         # self.radio.n_output_channels
-        import pdb; pdb.set_trace()
         return FeatureKeyList(
-            label=[f"radio_{self.adaptor_type}_{i}" for i in range(self.radio.embed_dim)],
+            label=[f"{self.radio_type}_{self.adaptor_type}_{i}" for i in range(self.radio.embed_dim)],
             metainfo=["vfm" for i in range(self.radio.embed_dim)]
         )

--- a/scripts/data/compute_pca.py
+++ b/scripts/data/compute_pca.py
@@ -74,6 +74,9 @@ if __name__ == "__main__":
 
     dino_buf = []
 
+    base_label = image_pipeline.output_feature_keys.label[0].rsplit('_', 1)[0]
+    base_metainfo = image_pipeline.output_feature_keys.metainfo[0]
+
     # check to see if single run or dir of runs
     run_dirs = []
     if config['odometry']['folder'] in os.listdir(args.data_dir):
@@ -176,7 +179,7 @@ if __name__ == "__main__":
 
     U, S, V = torch.pca_lowrank(dino_feats_norm, q=args.pca_nfeats)
 
-    pca_res = {"mean": feat_mean.cpu(), "V": V.cpu()}
+    pca_res = {"mean": feat_mean.cpu(), "V": V.cpu(), "base_label": base_label, "base_metainfo": base_metainfo}
     torch.save(pca_res, args.save_to)
 
     dino_feats_proj = dino_feats_norm @ V


### PR DESCRIPTION
Improve FeatureKey generation. DinoV2 and RadioLang blocks now produce the name of the VFM stored, and PCA block/creation script appends "_pca" to this. This means that it is much clearer what VFM produces what visual feature (as opposed to the generic "vfm"/"dino" keys).

Tested on KITTI and backward compatability with old pca files still works (will produce the generic "pca" key).