### PR TITLE
Add update to GaussKernelAttn module to enable compatibility with newer timm API

### DIFF
--- a/physics_atv_visual_mapping/image_processing/processing_blocks/radio_lang.py
+++ b/physics_atv_visual_mapping/image_processing/processing_blocks/radio_lang.py
@@ -55,7 +55,7 @@ class GaussKernelAttn(nn.Module):
     self.device = device
     self.num_prefix_tokens = num_prefix_tokens
 
-  def forward(self, x: torch.Tensor, attn_mask=None) -> torch.Tensor:
+  def forward(self, x: torch.Tensor, attn_mask=None, is_causal: bool = False) -> torch.Tensor:
     B, N, C = x.shape
     h, w = self.input_resolution
     n_patches = (w // 16, h //16)


### PR DESCRIPTION
Adds update to `forward` function of `GaussKernelAttn` module (used as part of `RadioLangBlock`) to enable compatibility with newer package versions of `timm`. 

Originally part of `utonia_colorizer` branch, committing here for easier integration with dependency upgrades

Enables removal of `timm` version pin in pip requirements